### PR TITLE
Fix php redis extension not found

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
         "intervention/image": "^3.11",
         "laravel/framework": "^12.0",
         "laravel/tinker": "^2.10.1",
+        "predis/predis": "^2.2",
         "tightenco/ziggy": "^2.4"
     },
     "require-dev": {

--- a/config/database.php
+++ b/config/database.php
@@ -143,7 +143,7 @@ return [
 
     'redis' => [
 
-        'client' => env('REDIS_CLIENT', 'phpredis'),
+        'client' => env('REDIS_CLIENT', 'predis'),
 
         'options' => [
             'cluster' => env('REDIS_CLUSTER', 'redis'),

--- a/dokploy/scripts/container-redis-check.sh
+++ b/dokploy/scripts/container-redis-check.sh
@@ -39,6 +39,10 @@ fi
 
 log_success "Container environment detected"
 
+# Determine client
+REDIS_CLIENT=${REDIS_CLIENT:-phpredis}
+log_info "Using Redis client: ${REDIS_CLIENT}"
+
 # 1. Check PHP installation
 log_info "🔧 Checking PHP installation..."
 if command -v php &> /dev/null; then
@@ -49,29 +53,35 @@ else
     exit 1
 fi
 
-# 2. Check PHP modules
+# 2. Check PHP modules (only relevant for phpredis)
 log_info "🔧 Checking PHP modules..."
 PHP_MODULES=$(php -m)
 echo "Available PHP modules:"
 echo "$PHP_MODULES"
 
-if echo "$PHP_MODULES" | grep -q redis; then
-    log_success "Redis extension is loaded"
-    REDIS_VERSION=$(php -r "echo phpversion('redis');" 2>/dev/null || echo "unknown")
-    echo "  - Redis extension version: $REDIS_VERSION"
+if [ "$REDIS_CLIENT" = "predis" ]; then
+    log_info "Predis selected: skipping PHP redis extension checks"
 else
-    log_error "Redis extension is NOT loaded"
-    echo "  - This means nixpacks build didn't install Redis extension"
-    echo "  - Check nixpacks build logs for Redis extension installation"
+    if echo "$PHP_MODULES" | grep -q redis; then
+        log_success "Redis extension is loaded"
+        REDIS_VERSION=$(php -r "echo phpversion('redis');" 2>/dev/null || echo "unknown")
+        echo "  - Redis extension version: $REDIS_VERSION"
+    else
+        log_error "Redis extension is NOT loaded"
+        echo "  - This means nixpacks build didn't install Redis extension"
+        echo "  - Check nixpacks build logs for Redis extension installation"
+    fi
 fi
 
-# 3. Check Redis class availability
-log_info "🔧 Checking Redis class availability..."
-if php -r "echo class_exists('Redis') ? 'OK' : 'FAIL';" 2>/dev/null | grep -q "OK"; then
-    log_success "Redis class is available"
-else
-    log_error "Redis class is NOT available"
-    echo "  - This confirms the 'Class Redis not found' error"
+# 3. Check Redis class availability (only meaningful for phpredis)
+if [ "$REDIS_CLIENT" != "predis" ]; then
+    log_info "🔧 Checking Redis class availability..."
+    if php -r "echo class_exists('Redis') ? 'OK' : 'FAIL';" 2>/dev/null | grep -q "OK"; then
+        log_success "Redis class is available"
+    else
+        log_error "Redis class is NOT available"
+        echo "  - This confirms the 'Class Redis not found' error"
+    fi
 fi
 
 # 4. Check environment variables
@@ -87,47 +97,55 @@ echo "  - REDIS_PORT: $REDIS_PORT"
 echo "  - REDIS_PASSWORD: ${REDIS_PASSWORD:-'not set'}"
 echo "  - REDIS_DB: $REDIS_DB"
 
-# 5. Test Redis connection (if extension available)
+# 5. Test Redis connection
 log_info "🔧 Testing Redis connection..."
-if echo "$PHP_MODULES" | grep -q redis; then
-    log_success "Redis extension available for connection test"
-    
-    # Test basic Redis connection
-    echo "Testing Redis connection to $REDIS_HOST:$REDIS_PORT..."
-    if php -r "
-        try {
-            \$redis = new Redis();
-            \$redis->connect('$REDIS_HOST', $REDIS_PORT);
-            if (!empty('$REDIS_PASSWORD')) {
-                \$redis->auth('$REDIS_PASSWORD');
-            }
-            echo 'PONG: ' . \$redis->ping() . PHP_EOL;
-        } catch (Exception \$e) {
-            echo 'ERROR: ' . \$e->getMessage() . PHP_EOL;
-        }
-    " 2>/dev/null; then
-        log_success "Redis connection test successful"
-    else
-        log_error "Redis connection test failed"
-    fi
-    
-    # Test Laravel Redis
+if [ "$REDIS_CLIENT" = "predis" ]; then
     if php artisan tinker --execute="Redis::connection()->ping();" > /dev/null 2>&1; then
-        log_success "Laravel Redis connection successful"
+        log_success "Laravel Redis connection successful (Predis)"
     else
-        log_error "Laravel Redis connection failed"
+        log_error "Laravel Redis connection failed (Predis)"
     fi
 else
-    log_error "Cannot test Redis connection - extension not available"
+    if echo "$PHP_MODULES" | grep -q redis; then
+        log_success "Redis extension available for connection test"
+        
+        # Test basic Redis connection
+        echo "Testing Redis connection to $REDIS_HOST:$REDIS_PORT..."
+        if php -r "
+            try {
+                $redis = new Redis();
+                $redis->connect('$REDIS_HOST', $REDIS_PORT);
+                if (!empty('$REDIS_PASSWORD')) {
+                    $redis->auth('$REDIS_PASSWORD');
+                }
+                echo 'PONG: ' . $redis->ping() . PHP_EOL;
+            } catch (Exception $e) {
+                echo 'ERROR: ' . $e->getMessage() . PHP_EOL;
+            }
+        " 2>/dev/null; then
+            log_success "Redis connection test successful"
+        else
+            log_error "Redis connection test failed"
+        fi
+        
+        # Test Laravel Redis
+        if php artisan tinker --execute="Redis::connection()->ping();" > /dev/null 2>&1; then
+            log_success "Laravel Redis connection successful"
+        else
+            log_error "Laravel Redis connection failed"
+        fi
+    else
+        log_error "Cannot test Redis connection - extension not available"
+    fi
 fi
 
 # 6. Check nixpacks build
 log_info "🔧 Checking nixpacks configuration..."
 if [ -f "/app/nixpacks.toml" ]; then
     if grep -q "php83Extensions.redis" /app/nixpacks.toml; then
-        log_success "Redis extension included in nixpacks.toml"
+        log_info "Redis extension referenced in nixpacks.toml"
     else
-        log_error "Redis extension missing from nixpacks.toml"
+        log_success "No redis extension in nixpacks.toml (expected when using Predis)"
     fi
 else
     log_info "nixpacks.toml not found in container"
@@ -139,25 +157,21 @@ echo ""
 echo "📋 CONTAINER CHECK SUMMARY:"
 echo "- Container environment: ✅"
 echo "- PHP installed: $(command -v php > /dev/null && echo "✅" || echo "❌")"
+echo "- Redis client: ${REDIS_CLIENT}"
 echo "- Redis extension loaded: $(php -m | grep -q redis && echo "✅" || echo "❌")"
 echo "- Redis class available: $(php -r "echo class_exists('Redis') ? 'OK' : 'FAIL';" 2>/dev/null | grep -q "OK" && echo "✅" || echo "❌")"
 echo "- Environment variables: $(echo $REDIS_HOST | grep -q "127.0.0.1" && echo "❌" || echo "✅")"
-echo "- Nixpacks Redis config: $(grep -q "php83Extensions.redis" /app/nixpacks.toml 2>/dev/null && echo "✅" || echo "❌")"
+echo "- Nixpacks Redis config: $(grep -q "php83Extensions.redis" /app/nixpacks.toml 2>/dev/null && echo "❌" || echo "✅")"
 echo ""
 echo "🔧 TROUBLESHOOTING:"
 echo ""
-echo "IF REDIS EXTENSION NOT LOADED:"
-echo "1. Check nixpacks build logs in Dokploy Dashboard"
-echo "2. Verify nixpacks.toml has 'php83Extensions.redis'"
-echo "3. Redeploy with rebuild option in Dokploy Dashboard"
+echo "IF USING PREDIS:"
+echo "- Ensure composer installed predis/predis and config/database.php has client=predis or env REDIS_CLIENT=predis"
 echo ""
-echo "IF REDIS CONNECTION FAILS:"
-echo "1. Set environment variables in Dokploy Dashboard:"
-echo "   REDIS_HOST=homsjogja-redis-qmihbb"
-echo "   REDIS_PORT=6379"
-echo "   REDIS_PASSWORD=5vlcwpzc45g9mtho"
-echo "   REDIS_DB=0"
-echo "2. Redeploy application"
+echo "IF USING PHPREDIS:"
+echo "1. Check nixpacks build logs in Dokploy Dashboard"
+echo "2. Verify nixpacks.toml has 'php83Extensions.redis' (if you intend to use phpredis)"
+echo "3. Redeploy with rebuild option in Dokploy Dashboard"
 echo ""
 echo "IF LARAVEL STILL SHOWS 'Class Redis not found':"
 echo "1. Clear Laravel cache: php artisan config:clear"
@@ -165,7 +179,6 @@ echo "2. Check if Redis extension is loaded: php -m | grep redis"
 echo "3. Verify Redis class exists: php -r \"echo class_exists('Redis') ? 'OK' : 'FAIL';\""
 echo ""
 echo "🎯 EXPECTED RESULT:"
-echo "- Redis extension installed and loaded in container"
-echo "- Redis class available for Laravel"
+echo "- Predis or phpredis operational in container"
 echo "- Laravel can connect to external Redis service"
 echo "- No more 'Class Redis not found' errors"

--- a/dokploy/scripts/startup.sh
+++ b/dokploy/scripts/startup.sh
@@ -109,127 +109,145 @@ else
     echo "⚠️ Database connection failed"
 fi
 
-# Test Redis extension and connection
-echo "🔍 Testing Redis extension and connection..."
-
-# Check if Redis extension is loaded
-if php -m | grep -q redis; then
-    echo "✅ Redis extension installed and loaded"
-    REDIS_VERSION=$(php -r "echo phpversion('redis');" 2>/dev/null || echo "unknown")
-    echo "  - Redis extension version: $REDIS_VERSION"
-    
-    # Test Redis class availability
-    if php -r "echo class_exists('Redis') ? 'OK' : 'FAIL';" 2>/dev/null | grep -q "OK"; then
-        echo "✅ Redis class is available"
-        
-        # Test Redis connection with environment variables
-        echo "🔍 Testing Redis connection to external service..."
-        REDIS_HOST=${REDIS_HOST:-"127.0.0.1"}
-        REDIS_PORT=${REDIS_PORT:-"6379"}
-        echo "Using Redis: ${REDIS_HOST}:${REDIS_PORT}"
-        
-        if php artisan tinker --execute="Redis::connection()->ping();" > /dev/null 2>&1; then
-            echo "✅ Redis connection successful"
-        else
-            echo "⚠️ Redis connection failed - check REDIS_HOST and REDIS_PORT"
-            echo "Current Redis config:"
-            echo "  - REDIS_HOST: ${REDIS_HOST}"
-            echo "  - REDIS_PORT: ${REDIS_PORT}"
-            echo "  - REDIS_PASSWORD: ${REDIS_PASSWORD:-'not set'}"
-        fi
+# Test Redis client and connection
+echo "🔍 Testing Redis client and connection..."
+REDIS_CLIENT=${REDIS_CLIENT:-phpredis}
+if [ "$REDIS_CLIENT" = "predis" ]; then
+    echo "✅ Using Predis client - PHP Redis extension not required"
+    REDIS_HOST=${REDIS_HOST:-"127.0.0.1"}
+    REDIS_PORT=${REDIS_PORT:-"6379"}
+    echo "Using Redis: ${REDIS_HOST}:${REDIS_PORT}"
+    if php artisan tinker --execute="Redis::connection()->ping();" > /dev/null 2>&1; then
+        echo "✅ Redis connection successful (Predis)"
     else
-        echo "❌ Redis class not available despite extension being loaded"
+        echo "⚠️ Redis connection failed (Predis) - check REDIS_HOST and REDIS_PORT"
+        echo "Current Redis config:"
+        echo "  - REDIS_HOST: ${REDIS_HOST}"
+        echo "  - REDIS_PORT: ${REDIS_PORT}"
+        echo "  - REDIS_PASSWORD: ${REDIS_PASSWORD:-'not set'}"
     fi
 else
-    echo "❌ Redis extension not installed or not loaded"
-    echo "  - This means nixpacks build didn't install Redis extension properly"
-    echo "  - Check nixpacks build logs for Redis extension installation"
-    echo "  - Available PHP modules:"
-    php -m | head -10 | tr '\n' ' '
-    echo ""
-    
-    # Run detailed Redis diagnosis and force install if needed
-    echo "🔍 Running detailed Redis diagnosis..."
-    if [ -f "dokploy/scripts/diagnose-redis-extension.sh" ]; then
-        echo "Running diagnose-redis-extension.sh..."
-        bash dokploy/scripts/diagnose-redis-extension.sh
-    else
-        echo "Diagnosis script not found, running manual checks..."
+    echo "🔍 Testing Redis extension and connection..."
+
+    # Check if Redis extension is loaded
+    if php -m | grep -q redis; then
+        echo "✅ Redis extension installed and loaded"
+        REDIS_VERSION=$(php -r "echo phpversion('redis');" 2>/dev/null || echo "unknown")
+        echo "  - Redis extension version: $REDIS_VERSION"
         
-        # Manual Redis diagnosis
-        echo "📋 MANUAL REDIS DIAGNOSIS:"
-        echo "1. Checking nixpacks.toml Redis extension..."
-        if grep -q "php83Extensions.redis" nixpacks.toml; then
-            echo "   ✅ Redis extension included in nixpacks.toml"
-        else
-            echo "   ❌ Redis extension missing from nixpacks.toml"
-        fi
-        
-        echo "2. Checking PHP installation..."
-        if command -v php &> /dev/null; then
-            PHP_VERSION=$(php -v | head -n1 | cut -d' ' -f2)
-            echo "   ✅ PHP installed: $PHP_VERSION"
-        else
-            echo "   ❌ PHP not installed"
-        fi
-        
-        echo "3. Checking PHP modules..."
-        PHP_MODULES=$(php -m)
-        if echo "$PHP_MODULES" | grep -q redis; then
-            echo "   ✅ Redis extension is loaded"
-        else
-            echo "   ❌ Redis extension is NOT loaded"
-            echo "   Available modules (first 10):"
-            echo "$PHP_MODULES" | head -10
-        fi
-        
-        echo "4. Checking Redis class availability..."
+        # Test Redis class availability
         if php -r "echo class_exists('Redis') ? 'OK' : 'FAIL';" 2>/dev/null | grep -q "OK"; then
-            echo "   ✅ Redis class is available"
-        else
-            echo "   ❌ Redis class is NOT available"
-        fi
-        
-        echo "5. Checking environment variables..."
-        REDIS_HOST=${REDIS_HOST:-"127.0.0.1"}
-        REDIS_PORT=${REDIS_PORT:-"6379"}
-        echo "   - REDIS_HOST: $REDIS_HOST"
-        echo "   - REDIS_PORT: $REDIS_PORT"
-        echo "   - REDIS_PASSWORD: ${REDIS_PASSWORD:-'not set'}"
-        
-        echo "6. Checking Laravel Redis configuration..."
-        if [ -f "config/database.php" ]; then
-            if grep -q "REDIS_HOST" config/database.php; then
-                echo "   ✅ Laravel Redis config uses environment variables"
+            echo "✅ Redis class is available"
+            
+            # Test Redis connection with environment variables
+            echo "🔍 Testing Redis connection to external service..."
+            REDIS_HOST=${REDIS_HOST:-"127.0.0.1"}
+            REDIS_PORT=${REDIS_PORT:-"6379"}
+            echo "Using Redis: ${REDIS_HOST}:${REDIS_PORT}"
+            
+            if php artisan tinker --execute="Redis::connection()->ping();" > /dev/null 2>&1; then
+                echo "✅ Redis connection successful"
             else
-                echo "   ❌ Laravel Redis config not using environment variables"
+                echo "⚠️ Redis connection failed - check REDIS_HOST and REDIS_PORT"
+                echo "Current Redis config:"
+                echo "  - REDIS_HOST: ${REDIS_HOST}"
+                echo "  - REDIS_PORT: ${REDIS_PORT}"
+                echo "  - REDIS_PASSWORD: ${REDIS_PASSWORD:-'not set'}"
             fi
         else
-            echo "   ❌ Laravel database config not found"
+            echo "❌ Redis class not available despite extension being loaded"
         fi
-    fi
-    
-    # Try to force install Redis extension if not available
-    echo "🔧 Attempting to force install Redis extension..."
-    if [ -f "dokploy/scripts/force-redis-install.sh" ]; then
-        echo "Running force-redis-install.sh..."
-        bash dokploy/scripts/force-redis-install.sh
     else
-        echo "Force install script not found"
-    fi
-    
-    # If Redis is still not available, fix session and cache issues
-    echo "🔧 Checking if Redis is still not available..."
-    if ! php -m | grep -q redis || ! php -r "echo class_exists('Redis') ? 'OK' : 'FAIL';" 2>/dev/null | grep -q "OK"; then
-        echo "⚠️ Redis extension still not available, fixing session and cache issues..."
-        if [ -f "dokploy/scripts/fix-session-cache-redis.sh" ]; then
-            echo "Running fix-session-cache-redis.sh..."
-            bash dokploy/scripts/fix-session-cache-redis.sh
+        echo "❌ Redis extension not installed or not loaded"
+        echo "  - This means nixpacks build didn't install Redis extension properly"
+        echo "  - Check nixpacks build logs for Redis extension installation"
+        echo "  - Available PHP modules:"
+        php -m | head -10 | tr '\n' ' '
+        echo ""
+        
+        # Run detailed Redis diagnosis and force install if needed
+        echo "🔍 Running detailed Redis diagnosis..."
+        if [ -f "dokploy/scripts/diagnose-redis-extension.sh" ]; then
+            echo "Running diagnose-redis-extension.sh..."
+            bash dokploy/scripts/diagnose-redis-extension.sh
         else
-            echo "Fix session/cache script not found"
+            echo "Diagnosis script not found, running manual checks..."
+            
+            # Manual Redis diagnosis
+            echo "📋 MANUAL REDIS DIAGNOSIS:"
+            echo "1. Checking nixpacks.toml Redis extension..."
+            if grep -q "php83Extensions.redis" nixpacks.toml; then
+                echo "   ✅ Redis extension included in nixpacks.toml"
+            else
+                echo "   ❌ Redis extension missing from nixpacks.toml"
+            fi
+            
+            echo "2. Checking PHP installation..."
+            if command -v php &> /dev/null; then
+                PHP_VERSION=$(php -v | head -n1 | cut -d' ' -f2)
+                echo "   ✅ PHP installed: $PHP_VERSION"
+            else
+                echo "   ❌ PHP not installed"
+            fi
+            
+            echo "3. Checking PHP modules..."
+            PHP_MODULES=$(php -m)
+            if echo "$PHP_MODULES" | grep -q redis; then
+                echo "   ✅ Redis extension is loaded"
+            else
+                echo "   ❌ Redis extension is NOT loaded"
+                echo "   Available modules (first 10):"
+                echo "$PHP_MODULES" | head -10
+            fi
+            
+            echo "4. Checking Redis class availability..."
+            if php -r "echo class_exists('Redis') ? 'OK' : 'FAIL';" 2>/dev/null | grep -q "OK"; then
+                echo "   ✅ Redis class is available"
+            else
+                echo "   ❌ Redis class is NOT available"
+            fi
+            
+            echo "5. Checking environment variables..."
+            REDIS_HOST=${REDIS_HOST:-"127.0.0.1"}
+            REDIS_PORT=${REDIS_PORT:-"6379"}
+            echo "   - REDIS_HOST: $REDIS_HOST"
+            echo "   - REDIS_PORT: $REDIS_PORT"
+            echo "   - REDIS_PASSWORD: ${REDIS_PASSWORD:-'not set'}"
+            
+            echo "6. Checking Laravel Redis configuration..."
+            if [ -f "config/database.php" ]; then
+                if grep -q "REDIS_HOST" config/database.php; then
+                    echo "   ✅ Laravel Redis config uses environment variables"
+                else
+                    echo "   ❌ Laravel Redis config not using environment variables"
+                fi
+            else
+                echo "   ❌ Laravel database config not found"
+            fi
         fi
-    else
-        echo "✅ Redis extension is now available"
+        
+        # Try to force install Redis extension if not available
+        echo "🔧 Attempting to force install Redis extension..."
+        if [ -f "dokploy/scripts/force-redis-install.sh" ]; then
+            echo "Running force-redis-install.sh..."
+            bash dokploy/scripts/force-redis-install.sh
+        else
+            echo "Force install script not found"
+        fi
+        
+        # If Redis is still not available, fix session and cache issues
+        echo "🔧 Checking if Redis is still not available..."
+        if ! php -m | grep -q redis || ! php -r "echo class_exists('Redis') ? 'OK' : 'FAIL';" 2>/dev/null | grep -q "OK"; then
+            echo "⚠️ Redis extension still not available, fixing session and cache issues..."
+            if [ -f "dokploy/scripts/fix-session-cache-redis.sh" ]; then
+                echo "Running fix-session-cache-redis.sh..."
+                bash dokploy/scripts/fix-session-cache-redis.sh
+            else
+                echo "Fix session/cache script not found"
+            fi
+        else
+            echo "✅ Redis extension is now available"
+        fi
     fi
 fi
 

--- a/env.dokploy.template
+++ b/env.dokploy.template
@@ -17,6 +17,7 @@ DB_USERNAME=homs-user
 DB_PASSWORD=jD8-AKHx2gFCQ5gx3ouRJ
 
 # Redis Configuration (External Redis)
+REDIS_CLIENT=predis
 REDIS_HOST=homsjogja-redis-qmihbb
 REDIS_PASSWORD=5vlcwpzc45g9mtho
 REDIS_PORT=6379

--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -5,7 +5,6 @@ nixPkgs = [
     "nodejs_20",
     "php83",
     "php83Packages.composer",
-    "php83Extensions.redis",
     "curl",
     "git",
     "bash"
@@ -13,6 +12,7 @@ nixPkgs = [
 
 [phases.install]
 cmds = [
+    "composer update predis/predis --no-dev --no-interaction --prefer-dist --no-scripts || true",
     "composer install --no-dev --optimize-autoloader --no-interaction --prefer-dist --no-scripts",
     "npm ci --legacy-peer-deps"
 ]


### PR DESCRIPTION
Switches Laravel's Redis client to Predis to resolve "Class Redis not found" errors.

The `phpredis` extension was not reliably loading in the Nixpacks build environment, causing runtime failures. Predis, a pure PHP client, provides a more robust solution by removing the dependency on the native extension.

---
<a href="https://cursor.com/background-agent?bcId=bc-a673cc01-65e1-4d7a-8338-c9a07d214797">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a673cc01-65e1-4d7a-8338-c9a07d214797">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

