### PR TITLE
Fix dockerfile for missing vendor files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -90,6 +90,7 @@ RUN apk del autoconf g++ make pcre-dev postgresql-dev sqlite-dev || true
 
 # Composer
 COPY --from=composer:latest /usr/bin/composer /usr/bin/composer
+ENV COMPOSER_ALLOW_SUPERUSER=1
 
 # Workdir consistent with Nixpacks configs (nginx root and supervisor use /app)
 WORKDIR /app
@@ -99,6 +100,9 @@ COPY . .
 
 # Copy built assets from node stage
 COPY --from=node-builder /app/public/build ./public/build
+
+# Install PHP dependencies (must be before any artisan command)
+RUN composer install --no-dev --optimize-autoloader --no-interaction --prefer-dist || (composer clear-cache && composer install --no-dev --optimize-autoloader --no-interaction --prefer-dist)
 
 # Create application user first
 RUN addgroup -g 1000 www && \

--- a/dokploy/scripts/safe-startup.sh
+++ b/dokploy/scripts/safe-startup.sh
@@ -49,6 +49,17 @@ if [ ! -f "artisan" ]; then
     exit_with_error "Laravel artisan not found - invalid deployment"
 fi
 
+# Ensure composer dependencies are installed if missing
+if [ ! -f "vendor/autoload.php" ]; then
+    log_info "🔧 vendor/autoload.php missing, running composer install..."
+    export COMPOSER_ALLOW_SUPERUSER=1
+    if ! composer install --no-dev --optimize-autoloader --no-interaction --prefer-dist; then
+        log_warning "Composer install failed, clearing cache and retrying..."
+        composer clear-cache || true
+        composer install --no-dev --optimize-autoloader --no-interaction --prefer-dist || exit_with_error "Composer install failed"
+    fi
+fi
+
 # Create necessary directories with error handling
 log_info "📁 Creating necessary directories..."
 mkdir -p storage/logs storage/framework/cache storage/framework/sessions storage/framework/views bootstrap/cache || exit_with_error "Failed to create storage directories"


### PR DESCRIPTION
Install Composer dependencies during Docker build and add a runtime fallback to resolve `vendor/autoload.php` missing errors.

---
<a href="https://cursor.com/background-agent?bcId=bc-7fb15168-9164-4a41-b1aa-761c90aad50d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7fb15168-9164-4a41-b1aa-761c90aad50d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

