### PR TITLE
Fix invalid 'in:' rule for empty categories

### DIFF
--- a/app/Http/Controllers/Admin/FinanceController.php
+++ b/app/Http/Controllers/Admin/FinanceController.php
@@ -173,10 +173,13 @@ class FinanceController extends Controller
 
     public function storeExpense(Request $request)
     {
-        $validated = $request->validate([
+        // Get configured categories and types
+        $expenseCategories = array_keys(config('finance.expense_categories', []));
+        $expenseTypes = array_keys(config('finance.expense_types', []));
+        
+        // Build validation rules
+        $validationRules = [
             'property_id' => ['nullable', 'exists:properties,id'],
-            'expense_category' => ['required', 'in:'.implode(',', array_keys(config('finance.expense_categories')))],
-            'expense_type' => ['required', 'in:'.implode(',', array_keys(config('finance.expense_types')))],
             'description' => ['nullable', 'string', 'max:255'],
             'amount' => ['required', 'numeric', 'min:0'],
             'expense_date' => ['required', 'date'],
@@ -185,7 +188,23 @@ class FinanceController extends Controller
             'payment_method' => ['nullable', 'string', 'max:50'],
             'notes' => ['nullable', 'string', 'max:255'],
             'wallet_id' => ['nullable', 'exists:wallets,id'],
-        ]);
+        ];
+
+        // Add category validation if categories are configured
+        if (!empty($expenseCategories)) {
+            $validationRules['expense_category'] = ['required', 'in:' . implode(',', $expenseCategories)];
+        } else {
+            $validationRules['expense_category'] = ['required', 'string', 'max:50'];
+        }
+
+        // Add type validation if types are configured
+        if (!empty($expenseTypes)) {
+            $validationRules['expense_type'] = ['required', 'in:' . implode(',', $expenseTypes)];
+        } else {
+            $validationRules['expense_type'] = ['required', 'string', 'max:50'];
+        }
+        
+        $validated = $request->validate($validationRules);
 
         $expense = PropertyExpense::create([
             'property_id' => $validated['property_id'] ?? null,
@@ -260,13 +279,23 @@ class FinanceController extends Controller
 
         $walletCategories = array_keys(config('finance.wallet_transaction_categories', []));
         
-        $validated = $request->validate([
+        // Build validation rules
+        $validationRules = [
             'direction' => ['required', 'in:in,out'],
-            'category' => ['required', 'in:' . implode(',', $walletCategories)],
             'amount' => ['required', 'numeric', 'min:0.01'],
             'transaction_date' => ['required', 'date'],
             'description' => ['nullable', 'string', 'max:255'],
-        ]);
+        ];
+
+        // Only add 'in' validation if categories are available
+        if (!empty($walletCategories)) {
+            $validationRules['category'] = ['required', 'in:' . implode(',', $walletCategories)];
+        } else {
+            // If no categories configured, just require category to be a string
+            $validationRules['category'] = ['required', 'string', 'max:50'];
+        }
+        
+        $validated = $request->validate($validationRules);
 
         // Check balance untuk transaction OUT
         if ($validated['direction'] === 'out') {


### PR DESCRIPTION
This pull request contains changes generated by a Cursor Cloud Agent

<a href="https://cursor.com/background-agent?bcId=bc-35316bfb-b40d-4b76-9418-0a436bb27f63"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-35316bfb-b40d-4b76-9418-0a436bb27f63"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors expense and wallet transaction validation to handle empty category/type configs by falling back to string rules instead of invalid `in:` lists.
> 
> - **Backend (FinanceController)**:
>   - **Expense Validation (`storeExpense`)**:
>     - Build rules dynamically from `config('finance.expense_categories')` and `config('finance.expense_types')`.
>     - Fall back to `'string|max:50'` when configs are empty to avoid invalid `in:` rules.
>   - **Wallet Transaction Validation (`storeWalletTransaction`)**:
>     - Build `category` rule from `config('finance.wallet_transaction_categories')`.
>     - Fall back to `'string|max:50'` when configs are empty to avoid invalid `in:` rules.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0f62221a47088946886c50c48c667a2f1d7ce0d7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->